### PR TITLE
added progurad rules for Retrofit and Gson in gradle R8 full mode

### DIFF
--- a/proguards/retrofitGsonInR8FullMode.json
+++ b/proguards/retrofitGsonInR8FullMode.json
@@ -1,0 +1,4 @@
+{
+    "name": "Retrofit/Gson in R8 full model",
+    "link": "https://gist.github.com/AshwinN796/e8ab709dc6626f28a88bec0f18e5d5fb"
+  }


### PR DESCRIPTION
Current version of Retrofit (2.9.0) having issue with R8 full mode. To reproduce the same follow below steps
1. Open project with Retrofit &  Gson decencies.
1. add `android.enableR8.fullMode=true ` in gradle file.  (default true in AGP 8.0)
2. Build project in release mode.